### PR TITLE
Common Shell Websocket Service Fixes

### DIFF
--- a/shell-websocket.service/shell-websocket.service.ts
+++ b/shell-websocket.service/shell-websocket.service.ts
@@ -101,7 +101,7 @@ export class ShellWebsocketService implements IDisposable
         this.websocket.on(
             ShellHubIncomingMessages.connectionReady,
             _ => {
-                this.logger.trace('got connectionReady disconnect message');
+                this.logger.trace('got connectionReady message');
                 this.shellStateSubject.next({start: false, disconnect: false, delete: false, ready: true});
             }
         );

--- a/shell-websocket.service/shell-websocket.service.types.ts
+++ b/shell-websocket.service/shell-websocket.service.types.ts
@@ -18,3 +18,9 @@ export interface ShellState {
     delete: boolean;
     ready: boolean;
 }
+
+export interface TerminalSize
+{
+    rows: number;
+    columns: number;
+}

--- a/utility/disposable.ts
+++ b/utility/disposable.ts
@@ -1,0 +1,5 @@
+// ref: https://gist.github.com/dsherret/cf5d6bec3d0f791cef00
+export interface IDisposable
+{
+    dispose() : void;
+}


### PR DESCRIPTION
ZLI PR - https://github.com/bastionzero/zli/pull/85

+ Rename `websocket.service` => `shell-websocket.service` to more clearly disambiguate this websocket service used for shells from the websocket service used for ssm tunnels.
+ Adds an `ILogger` to this class for better debug messages.
+ Set `disconnect: true`in shell state update when handling `shellDelete` or websocket `onclose` events so that the `terminal` is properly disposed by zli in these cases.  