### PR TITLE
Add linter rules to enforce use of let or const for variable declarations

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,8 @@
         "no-trailing-spaces": ["error"],
         "quotes": ["error", "single"],
         "semi": ["error", "always"],
+        "no-var": ["error"],
+        "prefer-const": ["error"],
         "@typescript-eslint/no-unused-vars": "off",
 		"unused-imports/no-unused-imports": "error",
 		"unused-imports/no-unused-vars": [

--- a/keysplitting.service/keysplitting.service.ts
+++ b/keysplitting.service/keysplitting.service.ts
@@ -55,15 +55,15 @@ export class KeySplittingService {
     }
 
     public async getBZECertHash(currentIdToken: string): Promise<string> {
-        let BZECert = await this.getBZECert(currentIdToken);
+        const BZECert = await this.getBZECert(currentIdToken);
         return this.hashHelper(this.JSONstringifyOrder(BZECert)).toString('base64');
     }
 
     public async generateCerRand(): Promise<void> {
         // Helper function to generate and store our cerRand and cerRandSig
-        var cerRand = this.randomBytes(32);
+        const cerRand = this.randomBytes(32);
         this.data.cerRand = cerRand.toString('base64');
-        var cerRandSig = await this.signHelper(cerRand);
+        const cerRandSig = await this.signHelper(cerRand);
         this.data.cerRandSig = cerRandSig;
 
         // Update our config
@@ -73,8 +73,8 @@ export class KeySplittingService {
 
     public createNonce(): string {
         // Helper function to create a Nonce
-        let hashString = ''.concat(this.data.publicKey, this.data.cerRandSig, this.data.cerRand);
-        let nonce = this.hashHelper(Buffer.from(hashString, 'utf8')).toString('base64');
+        const hashString = ''.concat(this.data.publicKey, this.data.cerRandSig, this.data.cerRand);
+        const nonce = this.hashHelper(Buffer.from(hashString, 'utf8')).toString('base64');
         this.logger.debug(`Creating new nonce: ${nonce}`);
         return nonce;
     }
@@ -118,8 +118,8 @@ export class KeySplittingService {
         }
 
         // Validate the signature
-        let toValidate: Buffer = this.hashHelper(this.JSONstringifyOrder(message.payload));
-        let signature: Buffer = Buffer.from(message.signature, 'base64');
+        const toValidate: Buffer = this.hashHelper(this.JSONstringifyOrder(message.payload));
+        const signature: Buffer = Buffer.from(message.signature, 'base64');
         if (await ed.verify(signature, toValidate, this.targetPublicKey)) {
             return true;
         }
@@ -128,7 +128,7 @@ export class KeySplittingService {
 
     private JSONstringifyOrder(obj: any): Buffer {
         // Ref: https://stackoverflow.com/a/53593328/9186330
-        let allKeys: string[] = [];
+        const allKeys: string[] = [];
         JSON.stringify(obj, function (key, value) { allKeys.push(key); return value; });
         allKeys.sort();
         return Buffer.from(JSON.stringify( obj, allKeys), 'utf8');
@@ -136,7 +136,7 @@ export class KeySplittingService {
 
     public async buildDataMessage<TDataPayload>(targetId: string, action: string, currentIdToken: string, payload: TDataPayload): Promise<DataMessageWrapper> {
         // Build our payload
-        let dataMessage = {
+        const dataMessage = {
             payload: {
                 type: 'DATA',
                 action: action,
@@ -149,7 +149,7 @@ export class KeySplittingService {
         };
 
         // Then calculate our signature
-        let signature = await this.signMessagePayload<DataMessagePayload>(dataMessage);
+        const signature = await this.signMessagePayload<DataMessagePayload>(dataMessage);
 
         // Then build and return our wrapped object
         dataMessage.signature = signature;
@@ -160,7 +160,7 @@ export class KeySplittingService {
 
     public async buildSynMessage(targetId: string, action: string, currentIdToken: string): Promise<SynMessageWrapper> {
         // Build our payload
-        let synMessage = {
+        const synMessage = {
             payload: {
                 type: 'SYN',
                 action: action,
@@ -172,7 +172,7 @@ export class KeySplittingService {
         };
 
         // Then calculate our signature
-        let signature = await this.signMessagePayload<SynMessagePayload>(synMessage);
+        const signature = await this.signMessagePayload<SynMessagePayload>(synMessage);
 
         // Then build and return our wrapped object
         synMessage.signature = signature;
@@ -194,7 +194,7 @@ export class KeySplittingService {
 
     private async signHelper(toSign: Buffer): Promise<string> {
         // Helper function to sign a string for us
-        let hashedSign = this.hashHelper(toSign);
+        const hashedSign = this.hashHelper(toSign);
         return Buffer.from(await ed.sign(hashedSign, this.privateKey)).toString('base64');
     }
 

--- a/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
+++ b/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
@@ -75,8 +75,8 @@ export class SsmTunnelWebsocketService
     }
 
     public async sendData(data: Buffer) {
-        let base64EncData = data.toString('base64');
-        let len = base64EncData.length;
+        const base64EncData = data.toString('base64');
+        const len = base64EncData.length;
 
         try {
             // Batch the send data so that an individual message stays below the
@@ -85,12 +85,12 @@ export class SsmTunnelWebsocketService
 
             // Give some slack for the rest of the TunnelDataMessage (sequence
             // number + json encoding)
-            let maxChunkSize = HUB_RECEIVE_MAX_SIZE - 1024;
+            const maxChunkSize = HUB_RECEIVE_MAX_SIZE - 1024;
 
             while(offset < len) {
 
-                let chunkSize = Math.min(len - offset, maxChunkSize);
-                let dataMessage: TunnelDataMessage = {
+                const chunkSize = Math.min(len - offset, maxChunkSize);
+                const dataMessage: TunnelDataMessage = {
                     data: base64EncData.substr(offset, chunkSize),
                     sequenceNumber: this.sequenceNumber++
                 };
@@ -113,7 +113,7 @@ export class SsmTunnelWebsocketService
     private async sendPubKeyViaBastion(pubKey: SshPK.Key) {
         // key type and pubkey are space delimited in the resulting string
         // https://github.com/joyent/node-sshpk/blob/4342c21c2e0d3860f5268fd6fd8af6bdeddcc6fc/lib/formats/ssh.js#L99
-        let [keyType, sshPubKey] = pubKey.toString('ssh').split(' ');
+        const [keyType, sshPubKey] = pubKey.toString('ssh').split(' ');
 
         await this.sendAddSshPubKeyMessage({
             keyType: keyType,
@@ -159,9 +159,9 @@ export class SsmTunnelWebsocketService
         // key type and pubkey are space delimited in the resulting string
         // agent currently assuming key type of ssh-rsa
         // https://github.com/joyent/node-sshpk/blob/4342c21c2e0d3860f5268fd6fd8af6bdeddcc6fc/lib/formats/ssh.js#L99
-        let sshPubKey = this.sshPublicKey.toString('ssh').split(' ')[1];
+        const sshPubKey = this.sshPublicKey.toString('ssh').split(' ')[1];
 
-        let sshTunnelOpenData: SshOpenActionPayload = {
+        const sshTunnelOpenData: SshOpenActionPayload = {
             username: this.username,
             sshPubKey: sshPubKey
         };
@@ -190,7 +190,7 @@ export class SsmTunnelWebsocketService
         // Set up ReceiveData handler
         this.websocket.on(SsmTunnelHubIncomingMessages.ReceiveData, (dataMessage: TunnelDataMessage) => {
             try {
-                let buf = Buffer.from(dataMessage.data, 'base64');
+                const buf = Buffer.from(dataMessage.data, 'base64');
 
                 this.logger.debug(`received tunnel data message with sequence number ${dataMessage.sequenceNumber}`);
 
@@ -208,7 +208,7 @@ export class SsmTunnelWebsocketService
 
                 // Validate our HPointer
                 if (this.keySplittingService.validateHPointer(synAckMessage.synAckPayload.payload.hPointer) != true) {
-                    let errorString = '[SynAck] Error Validating HPointer!';
+                    const errorString = '[SynAck] Error Validating HPointer!';
                     this.logger.error(errorString);
                     throw new Error(errorString);
                 }
@@ -218,7 +218,7 @@ export class SsmTunnelWebsocketService
 
                 // Validate our signature
                 if (await this.keySplittingService.validateSignature<SynAckPayload>(synAckMessage.synAckPayload) != true) {
-                    let errorString = '[SynAck] Error Validating Signature!';
+                    const errorString = '[SynAck] Error Validating Signature!';
                     this.logger.error(errorString);
                     throw new Error(errorString);
                 }
@@ -237,14 +237,14 @@ export class SsmTunnelWebsocketService
 
                 // Validate our HPointer
                 if (this.keySplittingService.validateHPointer(dataAckMessage.dataAckPayload.payload.hPointer) != true) {
-                    let errorString = '[DataAck] Error Validating HPointer!';
+                    const errorString = '[DataAck] Error Validating HPointer!';
                     this.logger.error(errorString);
                     throw new Error(errorString);
                 }
 
                 // Validate our signature
                 if (await this.keySplittingService.validateSignature<DataAckPayload>(dataAckMessage.dataAckPayload) != true) {
-                    let errorString = '[DataAck] Error Validating Signature!';
+                    const errorString = '[DataAck] Error Validating Signature!';
                     this.logger.error(errorString);
                     throw new Error(errorString);
                 }
@@ -261,7 +261,7 @@ export class SsmTunnelWebsocketService
         });
 
         this.websocket.on(SsmTunnelHubIncomingMessages.ReceiveError, (errorMessage: ErrorMessageWrapper) => {
-            let errorPayload = errorMessage.errorPayload.payload;
+            const errorPayload = errorMessage.errorPayload.payload;
 
             // TODO: check signature on error payload
 
@@ -317,7 +317,7 @@ export class SsmTunnelWebsocketService
         if(this.websocket === undefined || this.websocket.state == HubConnectionState.Disconnected)
             throw new Error('Hub disconnected');
 
-        let response = await this.websocket.invoke<WebsocketResponse>(methodName, message);
+        const response = await this.websocket.invoke<WebsocketResponse>(methodName, message);
 
         // Handle Hub Error
         if(response.error) {


### PR DESCRIPTION
This adds new linter rules for enforcing consistency in variable declarations:

+ [no-var](https://eslint.org/docs/rules/no-var): This restricts usage of `var` keyword (function scoped variables)  in favor of using `let` (block-scoped) or `const` instead.

+ [prefer-const](https://eslint.org/docs/rules/prefer-const): This enforces any variable that is never reassigned in the code should always use the `const` keyword instead of `let` to improve readability of the code.