### PR TITLE
Add keysplitting data removal

### DIFF
--- a/keysplitting.service/keysplitting.service.ts
+++ b/keysplitting.service/keysplitting.service.ts
@@ -126,6 +126,10 @@ export class KeySplittingService {
         return false;
     }
 
+    public removeKeysplittingData(): void {
+        this.config.removeKeySplitting();
+    }
+
     private JSONstringifyOrder(obj: any): Buffer {
         // Ref: https://stackoverflow.com/a/53593328/9186330
         const allKeys: string[] = [];

--- a/keysplitting.service/keysplitting.service.types.ts
+++ b/keysplitting.service/keysplitting.service.types.ts
@@ -19,4 +19,5 @@ export function getDefaultKeysplittingConfig(): KeySplittingConfigSchema {
 export interface ConfigInterface {
     updateKeySplitting(data: KeySplittingConfigSchema): void
     loadKeySplitting(): KeySplittingConfigSchema
+    removeKeySplitting(): void
 }


### PR DESCRIPTION
This adds the functionality to remove any keysplitting related data. It is intended to be used before logging out.
The motivation behind this is that during the logout in the webapp UI we want to remove any data kept in local storage.
Note; we should update the zli to follow the changes made to this