### PR TITLE
(CWC-636) Shell Attachment for Keysplitting

### DIFF
--- a/shell-websocket.service/base-shell-websocket.service.ts
+++ b/shell-websocket.service/base-shell-websocket.service.ts
@@ -25,6 +25,8 @@ export abstract class BaseShellWebsocketService implements IShellWebsocketServic
     protected abstract handleResize(terminalSize: TerminalSize): Promise<void>;
     protected abstract handleShellStart(): Promise<void>;
 
+    public abstract shellReattach() : Promise<void>;
+
     constructor(
         protected logger: ILogger,
         protected authConfigService: AuthConfigService,
@@ -61,7 +63,7 @@ export abstract class BaseShellWebsocketService implements IShellWebsocketServic
 
             try {
                 await this.handleShellStart();
-                this.shellEventSubject.next({ type: ShellEventType.Start })
+                this.shellEventSubject.next({ type: ShellEventType.Start });
             } catch(err) {
                 this.logger.error(err);
                 this.shellEventSubject.next({ type: ShellEventType.Disconnect });

--- a/shell-websocket.service/shell-websocket.service.types.ts
+++ b/shell-websocket.service/shell-websocket.service.types.ts
@@ -6,7 +6,7 @@ export interface IShellWebsocketService extends IDisposable{
     sendShellConnect(rows: number, cols: number): void;
 
     outputData: Observable<string>;
-    shellStateData: Observable<ShellState>;
+    shellEventData: Observable<ShellEvent>;
 }
 
 export const ShellHubIncomingMessages = {
@@ -32,11 +32,16 @@ export const ShellHubOutgoingMessages = {
     dataMessage: 'DataMessage',
 };
 
-export interface ShellState {
-    start: boolean;
-    disconnect: boolean;
-    delete: boolean;
-    ready: boolean;
+export enum ShellEventType {
+    Start = 'Start',
+    Disconnect = 'Disconnect',
+    Delete = 'Delete',
+    Ready = 'Ready',
+    Unattached = 'Unattach'
+}
+
+export interface ShellEvent {
+    type: ShellEventType;
 }
 
 export interface TerminalSize

--- a/shell-websocket.service/shell-websocket.service.types.ts
+++ b/shell-websocket.service/shell-websocket.service.types.ts
@@ -4,6 +4,7 @@ import { IDisposable } from '../utility/disposable';
 export interface IShellWebsocketService extends IDisposable{
     start() : Promise<void>;
     sendShellConnect(rows: number, cols: number): void;
+    shellReattach() : Promise<void>;
 
     outputData: Observable<string>;
     shellEventData: Observable<ShellEvent>;

--- a/shell-websocket.service/ssh-shell-websocket.service.ts
+++ b/shell-websocket.service/ssh-shell-websocket.service.ts
@@ -37,4 +37,8 @@ export class SshShellWebsocketService extends BaseShellWebsocketService
     protected async handleResize(terminalSize: TerminalSize): Promise<void> {
         await this.sendWebsocketMessage(ShellHubOutgoingMessages.shellGeometry, terminalSize);
     }
+
+    public shellReattach(): Promise<void> {
+        return;
+    }
 }

--- a/shell-websocket.service/ssm-shell-websocket.service.ts
+++ b/shell-websocket.service/ssm-shell-websocket.service.ts
@@ -352,6 +352,6 @@ export class SsmShellWebsocketService extends BaseShellWebsocketService
         this.logger.error(`Type: ${errorPayload.errorType}`);
         this.logger.error(`Error Message: ${errorPayload.message}`);
 
-        this.shellStateSubject.next({start: false, disconnect: true, delete: false, ready: false});
+        this.shellEventSubject.next({ type: ShellEventType.Disconnect});
     }
 }


### PR DESCRIPTION
+ Emit a shell unattached event when receiving an unrecognized synack and stop sending any input in the websocket when not the active client.
+ The outer client scope should handle this by preventing new input and displaying a user facing message indicating the shell input been suspended and how to resume sending input.
+  When the user wishes to resume sending input the `shellReattach` method should be called will attempt to
reperform keysplitting handshake to become the actively attached client.

See https://github.com/bastionzero/zli/pull/92 for zli changes
See https://github.com/bastionzero/webshell-backend/pull/645 for web app changes