### PR TITLE
Set KeysplittingMinimumAgentVersion

### DIFF
--- a/keysplitting.service/keysplitting-types.ts
+++ b/keysplitting.service/keysplitting-types.ts
@@ -82,21 +82,25 @@ export interface ErrorMessageWrapper {
     errorPayload: ErrorMessage;
 }
 
+// Should be kept in sync with agent error types from
+// https://github.com/bastionzero/bzero-ssm-agent/blob/d5fac61c89b3b2af90faf2a3eec07e55ae123583/agent/keysplitting/contracts/model.go#L117-L133
+// Updated as of agent version 3.0.732.16
 export enum KeysplittingErrorTypes {
-    BZECertInvalidClientPublicKey   = 'BZECertInvalidClientPublicKey',
-    BZECertExpired                  = 'BZECertExpired',
-    BZECertInvalidIDToken           = 'BZECertInvalidIDToken',
-    BZECertInvalidNonce             = 'BZECertInvalidNonce',
-    BZECertUnrecognized             = 'BZECertUnrecognized',
-    BZECertInvalidProvider          = 'BZECertProviderError',
-    HPointerError                   = 'HPointerError',
-    SigningError                    = 'SigningError',
-    SignatureVerificationError      = 'SignatureVerificationError',
-    TargetIdInvalid                 = 'TargetIdInvalid',
-    HashingError                    = 'HashingError',
-    KeysplittingActionError         = 'KeysplittingActionError',
-    InvalidPayload                  = 'InvalidPayload',
-    Unknown                         = 'Unknown',
+    BZECertInvalidIDToken       = 'BZECertInvalidIDToken',
+	BZECertInvalidNonce         = 'BZECertInvalidNonce',
+	BZECertUnrecognized         = 'BZECertUnrecognized',
+	BZECertInvalidProvider      = 'BZECertProviderError',
+	BZECertExpired              = 'BZECertExpired',
+	HPointerError               = 'HPointerError',
+	SigningError                = 'SigningError',
+	SignatureVerificationError  = 'SignatureVerificationError',
+	TargetIdInvalid             = 'TargetIdInvalid',
+	HashingError                = 'HashingError',
+	KeysplittingActionError     = 'KeysplittingActionError',
+	InvalidPayload              = 'InvalidPayload',
+	Unknown                     = 'Unknown',
+	ChannelClosed               = 'ChannelClosed',
+	OutdatedHPointer            = 'OutdatedHPointer'
 }
 
 export enum SshTunnelActions {

--- a/shell-websocket.service/ssm-shell-websocket.service.ts
+++ b/shell-websocket.service/ssm-shell-websocket.service.ts
@@ -14,9 +14,9 @@ interface ShellMessage {
     seqNum: number;
 }
 
-// TODO: change this after we release keysplitting agent version
-// This is bzero agent version only "3.0.732.15" => 15
-const KeysplittingMinimumAgentVersion = 0;
+// bzero-agent version >= 3.0.732.16 is keysplitting compatible for interactive shells
+const KeysplittingMinimumAgentVersion = 16;
+
 export function isAgentKeysplittingReady(agentVersion: string): boolean {
     try {
         const version = parseInt(agentVersion.split('.')[3]);


### PR DESCRIPTION
+ Now that we have finalized the agent version that will contain the keysplitting protocol changes for interactive shell set the KeysplittingMinimumAgentVersion to 3.0.732.16.
+ Update keysplitting Error Types to match agent's