### PR TITLE
Fix/websocket timeout breaking [CWC-655]

### DIFF
--- a/shell-websocket.service/shell-websocket.service.ts
+++ b/shell-websocket.service/shell-websocket.service.ts
@@ -127,7 +127,6 @@ export class ShellWebsocketService implements IDisposable
     public async createConnection(): Promise<HubConnection> {
         // connectionId is related to terminal session
         // sessionId is for user authentication
-        console.log("I AM USED2")
         const queryString = `?connectionId=${this.connectionId}&session_id=${this.authConfigService.getSessionId()}`;
 
         const connectionUrl = `${this.authConfigService.getServiceUrl()}hub/ssh/${queryString}`;

--- a/shell-websocket.service/shell-websocket.service.ts
+++ b/shell-websocket.service/shell-websocket.service.ts
@@ -133,12 +133,12 @@ export class ShellWebsocketService implements IDisposable
 
         const connectionBuilder = new HubConnectionBuilder();
         connectionBuilder
-        .withUrl(
-            connectionUrl,
-            { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
-        )
-        .configureLogging(6) // log level 6 is no websocket logs
-        .withAutomaticReconnect();
+            .withUrl(
+                connectionUrl,
+                { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
+            )
+            .configureLogging(6) // log level 6 is no websocket logs
+            .withAutomaticReconnect();
         return connectionBuilder.build();
     }
 

--- a/shell-websocket.service/shell-websocket.service.ts
+++ b/shell-websocket.service/shell-websocket.service.ts
@@ -127,15 +127,19 @@ export class ShellWebsocketService implements IDisposable
     public async createConnection(): Promise<HubConnection> {
         // connectionId is related to terminal session
         // sessionId is for user authentication
+        console.log("I AM USED2")
         const queryString = `?connectionId=${this.connectionId}&session_id=${this.authConfigService.getSessionId()}`;
 
         const connectionUrl = `${this.authConfigService.getServiceUrl()}hub/ssh/${queryString}`;
 
         const connectionBuilder = new HubConnectionBuilder();
-        connectionBuilder.withUrl(
+        connectionBuilder
+        .withUrl(
             connectionUrl,
             { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
-        ).configureLogging(6); // log level 6 is no websocket logs
+        )
+        .configureLogging(6) // log level 6 is no websocket logs
+        .withAutomaticReconnect();
         return connectionBuilder.build();
     }
 

--- a/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
+++ b/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
@@ -287,12 +287,12 @@ export class SsmTunnelWebsocketService
 
         const connectionBuilder = new HubConnectionBuilder();
         connectionBuilder
-        .withUrl(
-            connectionUrl,
-            { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
-        )
-        .configureLogging(new SignalRLogger(this.logger))
-        .withAutomaticReconnect();
+            .withUrl(
+                connectionUrl,
+                { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
+            )
+            .configureLogging(new SignalRLogger(this.logger))
+            .withAutomaticReconnect();
         return connectionBuilder.build();
     }
 

--- a/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
+++ b/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
@@ -291,8 +291,7 @@ export class SsmTunnelWebsocketService
                 connectionUrl,
                 { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
             )
-            .configureLogging(new SignalRLogger(this.logger))
-            .withAutomaticReconnect();
+            .configureLogging(new SignalRLogger(this.logger));
         return connectionBuilder.build();
     }
 

--- a/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
+++ b/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
@@ -286,10 +286,13 @@ export class SsmTunnelWebsocketService
         const connectionUrl = `${this.authConfigService.getServiceUrl()}hub/ssm-tunnel/${queryString}`;
 
         const connectionBuilder = new HubConnectionBuilder();
-        connectionBuilder.withUrl(
+        connectionBuilder
+        .withUrl(
             connectionUrl,
             { accessTokenFactory: async () => await this.authConfigService.getIdToken()}
-        ).configureLogging(new SignalRLogger(this.logger));
+        )
+        .configureLogging(new SignalRLogger(this.logger))
+        .withAutomaticReconnect();
         return connectionBuilder.build();
     }
 


### PR DESCRIPTION
This addresses CWC-655. The issue was that after a tab with an open connection was hidden (inactive) for some minutes, the  websocket would stop sending keep alive messages. Changed this to automatically reconnect.

In order to test this open a connection and leave that tab open. Open another tab to an irrelevant website. After ~6mins go back to the bzero tab. Everything should work as expected instead of showing a "Connection interrupted" message.