### PR TITLE
Add close ssm tunnel websocket method [CWC-628]

### DIFF
--- a/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
+++ b/ssm-tunnel-websocket.service/ssm-tunnel-websocket.service.ts
@@ -111,6 +111,13 @@ export class SsmTunnelWebsocketService
         }
     }
 
+    public async closeConnection(): Promise<void> {
+        if(this.websocket) {
+            await this.websocket.stop();
+            this.websocket = undefined;
+        }
+    }
+
     // This will send the pubkey through the bastion's AddSshPubKey websocket
     // method which uses RunCommand to add the ssh pubkey to the target's
     // authorized_keys file. This code path should ultimately be removed once
@@ -189,18 +196,12 @@ export class SsmTunnelWebsocketService
         await this.sendDataMessage(dataMessage);
     }
 
-    private async closeConnection() {
-        if(this.websocket) {
-            await this.websocket.stop();
-            this.websocket = undefined;
-        }
-    }
-
     private async setupWebsocket() {
         await this.startWebsocket();
 
         this.websocket.onclose((error) => {
-            this.handleError(`Websocket was closed by server: ${error}`);
+            if (error)
+                this.handleError(`Websocket was closed by server: ${error}`);
         });
 
         // Set up ReceiveData handler


### PR DESCRIPTION
## Description of the change

This adds a public method to close the websocket of an ssm tunnel. It also alters a little the way errors are reported during the closing of the websocket. Now the error will be reported only if it is not undefined. This is to avoid reporting an error when we intentionally close the websocket.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [X] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-628

## Potential Security Impacts

## Checklists

**Is this a merge into master? Are you planning on pushing to production?** Please make sure you verify everything on our [checklist](https://docs.google.com/spreadsheets/d/1bggg95-QCRgQpvhXOahhkTDWYZOzqfk16gBwTOj42v0/edit#gid=0) first!

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [X] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
