### PR TITLE
Handle shell plugin not ready

### DIFF
--- a/keysplitting.service/keysplitting-types.ts
+++ b/keysplitting.service/keysplitting-types.ts
@@ -101,7 +101,8 @@ export enum KeysplittingErrorTypes {
 	Unknown                      = 'Unknown',
 	ChannelClosed                = 'ChannelClosed',
 	OutdatedHPointer             = 'OutdatedHPointer',
-    BZECertExpiredInitialIdToken = "BZECertExpiredInitialIdToken"
+    BZECertExpiredInitialIdToken = "BZECertExpiredInitialIdToken",
+    HandlerNotReady              = "HandlerNotReady"
 }
 
 export enum SshTunnelActions {

--- a/keysplitting.service/keysplitting-types.ts
+++ b/keysplitting.service/keysplitting-types.ts
@@ -86,21 +86,22 @@ export interface ErrorMessageWrapper {
 // https://github.com/bastionzero/bzero-ssm-agent/blob/d5fac61c89b3b2af90faf2a3eec07e55ae123583/agent/keysplitting/contracts/model.go#L117-L133
 // Updated as of agent version 3.0.732.16
 export enum KeysplittingErrorTypes {
-    BZECertInvalidIDToken       = 'BZECertInvalidIDToken',
-	BZECertInvalidNonce         = 'BZECertInvalidNonce',
-	BZECertUnrecognized         = 'BZECertUnrecognized',
-	BZECertInvalidProvider      = 'BZECertProviderError',
-	BZECertExpired              = 'BZECertExpired',
-	HPointerError               = 'HPointerError',
-	SigningError                = 'SigningError',
-	SignatureVerificationError  = 'SignatureVerificationError',
-	TargetIdInvalid             = 'TargetIdInvalid',
-	HashingError                = 'HashingError',
-	KeysplittingActionError     = 'KeysplittingActionError',
-	InvalidPayload              = 'InvalidPayload',
-	Unknown                     = 'Unknown',
-	ChannelClosed               = 'ChannelClosed',
-	OutdatedHPointer            = 'OutdatedHPointer'
+    BZECertInvalidIDToken        = 'BZECertInvalidIDToken',
+	BZECertInvalidNonce          = 'BZECertInvalidNonce',
+	BZECertUnrecognized          = 'BZECertUnrecognized',
+	BZECertInvalidProvider       = 'BZECertProviderError',
+	BZECertExpired               = 'BZECertExpired',
+	HPointerError                = 'HPointerError',
+	SigningError                 = 'SigningError',
+	SignatureVerificationError   = 'SignatureVerificationError',
+	TargetIdInvalid              = 'TargetIdInvalid',
+	HashingError                 = 'HashingError',
+	KeysplittingActionError      = 'KeysplittingActionError',
+	InvalidPayload               = 'InvalidPayload',
+	Unknown                      = 'Unknown',
+	ChannelClosed                = 'ChannelClosed',
+	OutdatedHPointer             = 'OutdatedHPointer',
+    BZECertExpiredInitialIdToken = "BZECertExpiredInitialIdToken"
 }
 
 export enum SshTunnelActions {

--- a/keysplitting.service/keysplitting-types.ts
+++ b/keysplitting.service/keysplitting-types.ts
@@ -101,8 +101,8 @@ export enum KeysplittingErrorTypes {
 	Unknown                      = 'Unknown',
 	ChannelClosed                = 'ChannelClosed',
 	OutdatedHPointer             = 'OutdatedHPointer',
-    BZECertExpiredInitialIdToken = "BZECertExpiredInitialIdToken",
-    HandlerNotReady              = "HandlerNotReady"
+    BZECertExpiredInitialIdToken = 'BZECertExpiredInitialIdToken',
+    HandlerNotReady              = 'HandlerNotReady'
 }
 
 export enum SshTunnelActions {

--- a/shell-websocket.service/ssm-shell-websocket.service.ts
+++ b/shell-websocket.service/ssm-shell-websocket.service.ts
@@ -26,7 +26,7 @@ export function isAgentKeysplittingReady(agentVersion: string): boolean {
     }
 }
 
-const KeysplittingHandshakeTimeout = 25; // in seconds
+const KeysplittingHandshakeTimeout = 45; // in seconds
 
 export class SsmShellWebsocketService extends BaseShellWebsocketService
 {
@@ -377,14 +377,10 @@ export class SsmShellWebsocketService extends BaseShellWebsocketService
         this.logger.error(`Error Message: ${errorPayload.message}`);
 
         switch(errorPayload.errorType) {
-            case KeysplittingErrorTypes.Unknown:
-                // If there is an unknown error on a shell resize, then the pty isn't ready -> resend
-                if (this.currentInputMessage.inputType == ShellActions.Resize) {
-                    setTimeout(async () => {
-                        this.inputMessageBuffer.push(this.currentInputMessage);
-                        await this.processInputMessageQueue();  
-                    }, 2000);
-                }
+            case KeysplittingErrorTypes.HandlerNotReady:
+                await new Promise(resolve => setTimeout(resolve, 1000))
+                this.currentInputMessage = undefined;
+                await this.processInputMessageQueue();
                 break;
             default:
                 this.shellEventSubject.next({ type: ShellEventType.Disconnect});

--- a/shell-websocket.service/ssm-shell-websocket.service.ts
+++ b/shell-websocket.service/ssm-shell-websocket.service.ts
@@ -6,7 +6,7 @@ import { BaseShellWebsocketService } from './base-shell-websocket.service';
 import { AuthConfigService } from '../auth-config-service/auth-config.service';
 import { ILogger } from '../logging/logging.types';
 import { KeySplittingService } from '../keysplitting.service/keysplitting.service';
-import { DataAckMessageWrapper, DataAckPayload, DataMessageWrapper, ErrorMessageWrapper, ShellActions, ShellTerminalSizeActionPayload, SsmTargetInfo, SynAckMessageWrapper, SynAckPayload, SynMessageWrapper } from '../keysplitting.service/keysplitting-types';
+import { DataAckMessageWrapper, DataAckPayload, DataMessageWrapper, ErrorMessageWrapper, ShellActions, ShellTerminalSizeActionPayload, SsmTargetInfo, SynAckMessageWrapper, SynAckPayload, SynMessageWrapper, KeysplittingErrorTypes } from '../keysplitting.service/keysplitting-types';
 
 interface ShellMessage {
     inputType: ShellActions,
@@ -26,7 +26,7 @@ export function isAgentKeysplittingReady(agentVersion: string): boolean {
     }
 }
 
-const KeysplittingHandshakeTimeout = 15; // in seconds
+const KeysplittingHandshakeTimeout = 25; // in seconds
 
 export class SsmShellWebsocketService extends BaseShellWebsocketService
 {
@@ -376,6 +376,18 @@ export class SsmShellWebsocketService extends BaseShellWebsocketService
         this.logger.error(`Type: ${errorPayload.errorType}`);
         this.logger.error(`Error Message: ${errorPayload.message}`);
 
-        this.shellEventSubject.next({ type: ShellEventType.Disconnect});
+        switch(errorPayload.errorType) {
+            case KeysplittingErrorTypes.Unknown:
+                // If there is an unknown error on a shell resize, then the pty isn't ready -> resend
+                if (this.currentInputMessage.inputType == ShellActions.Resize) {
+                    setTimeout(async () => {
+                        this.inputMessageBuffer.push(this.currentInputMessage);
+                        await this.processInputMessageQueue();  
+                    }, 2000);
+                }
+                break;
+            default:
+                this.shellEventSubject.next({ type: ShellEventType.Disconnect});
+        }
     }
 }

--- a/shell-websocket.service/ssm-shell-websocket.service.ts
+++ b/shell-websocket.service/ssm-shell-websocket.service.ts
@@ -377,13 +377,13 @@ export class SsmShellWebsocketService extends BaseShellWebsocketService
         this.logger.error(`Error Message: ${errorPayload.message}`);
 
         switch(errorPayload.errorType) {
-            case KeysplittingErrorTypes.HandlerNotReady:
-                await new Promise(resolve => setTimeout(resolve, 1000))
-                this.currentInputMessage = undefined;
-                await this.processInputMessageQueue();
-                break;
-            default:
-                this.shellEventSubject.next({ type: ShellEventType.Disconnect});
+        case KeysplittingErrorTypes.HandlerNotReady:
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            this.currentInputMessage = undefined;
+            await this.processInputMessageQueue();
+            break;
+        default:
+            this.shellEventSubject.next({ type: ShellEventType.Disconnect});
         }
     }
 }


### PR DESCRIPTION
## Description of the change

If we send input messages too quickly to the agent we sometimes get an unknown keysplitting error indicating the underlying shell plugin is not ready to start receiving data. The shell immediately disconnects and the user is forced to click reconnect which generally fixes the issue. We should detect these cases in the agent and return a custom keysplitting error that we can handle on the client side in order to prevent sending input before shell plugin is ready. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-670

## Potential Security Impacts

Does this PR have any security impact? No
Does it fix a security issue? No
Does it add attack surface? No
Why do we think this change is safe? Because no to all of the above.

## Checklists

**Is this a merge into master? Are you planning on pushing to production?** Please make sure you verify everything on our [checklist](https://docs.google.com/spreadsheets/d/1bggg95-QCRgQpvhXOahhkTDWYZOzqfk16gBwTOj42v0/edit#gid=0) first!

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
