### PR TITLE
base-shell-websocket now has logic for disconnected websocket and rec…

### DIFF
--- a/shell-websocket.service/shell-websocket.service.types.ts
+++ b/shell-websocket.service/shell-websocket.service.types.ts
@@ -48,7 +48,8 @@ export enum ShellEventType {
     Disconnect = 'Disconnect',
     Delete = 'Delete',
     Ready = 'Ready',
-    Unattached = 'Unattach'
+    Unattached = 'Unattached',
+    BrokenWebsocket = 'BrokenWebsocket'
 }
 
 export interface ShellEvent {


### PR DESCRIPTION
…onnection

 - new ShellEventType.Disconnect

## Description of the change

When websocket breaks, send a shell event type for that, as we want to block input but not end the process of zli.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [ ] Enhancement (minor change below the level of a feature)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA:
https://commonwealthcrypto.atlassian.net/browse/CWC-696

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

**Is this a merge into master? Are you planning on pushing to production?** Please make sure you verify everything on our [checklist](https://docs.google.com/spreadsheets/d/1bggg95-QCRgQpvhXOahhkTDWYZOzqfk16gBwTOj42v0/edit#gid=0) first!

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [x] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
