### PR TITLE
Create common function to get autodiscovery script target name

### DIFF
--- a/autodiscovery-script/autodiscovery-script.ts
+++ b/autodiscovery-script/autodiscovery-script.ts
@@ -1,0 +1,22 @@
+import { TargetName } from './autodiscovery-script.types';
+
+export function getAutodiscoveryScriptTargetNameScript(targetName: TargetName): string {
+    switch (targetName.scheme) {
+    case 'digitalocean':
+        return 'TARGET_NAME=$(curl http://169.254.169.254/metadata/v1/hostname)';
+    case 'aws':
+        return String.raw`
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+TARGET_NAME=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)`;
+    case 'time':
+        return 'TARGET_NAME=target-$(date +"%m%d-%H%M%S")';
+    case 'hostname':
+        return 'TARGET_NAME=$(hostname)';
+    case 'manual':
+        return `TARGET_NAME=\"${targetName.name}\"`;
+    default:
+        // Compile-time exhaustive check
+        const _exhaustiveCheck: never = targetName;
+        return _exhaustiveCheck;
+    }
+}

--- a/autodiscovery-script/autodiscovery-script.types.ts
+++ b/autodiscovery-script/autodiscovery-script.types.ts
@@ -1,0 +1,27 @@
+export type TargetNameManual = {
+    name: string
+    scheme: 'manual'
+}
+
+export type TargetNameDigitalOcean = {
+    scheme: 'digitalocean'
+}
+
+export type TargetNameAWS = {
+    scheme: 'aws'
+}
+
+export type TargetNameTime = {
+    scheme: 'time'
+}
+
+export type TargetNameHostname = {
+    scheme: 'hostname'
+}
+
+export type TargetName =
+    | TargetNameManual
+    | TargetNameDigitalOcean
+    | TargetNameAWS
+    | TargetNameTime
+    | TargetNameHostname


### PR DESCRIPTION
## Description of the change

Adds extra type safety for getting the autodiscovery script target name script. The `zli` will start using this after https://github.com/bastionzero/zli/pull/166 is merged. Eventually, the webapp will be refactored to also use this function.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Refactor (code change with no functionality change)
- [x] Enhancement (minor change below the level of a feature)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Remove feature (removes a feature we don't support anymore)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related JIRA tickets

Relates to JIRA: CWC-1046

## Potential Security Impacts

Does this PR have any security impact?
Does it fix a security issue?
Does it add attack surface?
Why do we think this change is safe?

## Checklists

**Is this a merge into master? Are you planning on pushing to production?** Please make sure you verify everything on our [checklist](https://docs.google.com/spreadsheets/d/1bggg95-QCRgQpvhXOahhkTDWYZOzqfk16gBwTOj42v0/edit#gid=0) first!

### Development

- [ ] Does the code changed/added as part of this pull request have test coverage?
- [ ] Do all tests related to the changed code pass in development?
- [ ] Have you ensured that at least one other person has tested your code?
- [ ] Have you tested the code?
- [ ] Have you attached any pictures (if relevant)?
