### PR TITLE
Create BasePolicySummary and PolicyType string union

### DIFF
--- a/http/v2/policy/kubernetes-tunnel/types/kube-tunnel-policy-summary.types.ts
+++ b/http/v2/policy/kubernetes-tunnel/types/kube-tunnel-policy-summary.types.ts
@@ -1,33 +1,10 @@
+import { BasePolicySummary } from '../../types/base-policy-summary.types';
 import { ClusterGroup } from '../../types/cluster-group.types';
 import { ClusterUser } from '../../types/cluster-user.types';
 import { Cluster } from '../../types/cluster.types';
 import { Environment } from '../../types/environment.types';
-import { Group } from '../../types/group.types';
-import { PolicyType } from '../../types/policy-type.types';
-import { Subject } from '../../types/subject.types';
-
-export interface KubeTunnelPolicySummary {
-     /**
-      * Unique identifier for this policy.
-      */
-     id: string;
-     /**
-      * Name of policy.
-      */
-     name: string;
-     /**
-      * Description of policy.
-      */
-     description: string;
-     /**
-      * Users and API Keys that this policy applies to.
-      */
-     subjects: Subject[];
-     /**
-      * Groups that this policy applies to.
-      */
-     groups: Group[];
-     type: PolicyType;
+export interface KubeTunnelPolicySummary extends BasePolicySummary {
+     type: "KubernetesTunnel";
      /**
       * Environments this policy applies to.
       */

--- a/http/v2/policy/organization-controls/types/organization-controls-policy-summary.types.ts
+++ b/http/v2/policy/organization-controls/types/organization-controls-policy-summary.types.ts
@@ -1,29 +1,7 @@
-import { Group } from '../../types/group.types';
-import { PolicyType } from '../../types/policy-type.types';
-import { Subject } from '../../types/subject.types';
+import { BasePolicySummary } from '../../types/base-policy-summary.types';
 
-export interface OrganizationControlsPolicySummary {
-     /**
-      * Unique identifier for this policy.
-      */
-     id: string;
-     /**
-      * Name of policy.
-      */
-     name: string;
-     /**
-      * Description of policy.
-      */
-     description: string;
-     /**
-      * Users and API Keys that this policy applies to.
-      */
-     subjects: Subject[];
-     /**
-      * Groups that this policy applies to.
-      */
-     groups: Group[];
-     type: PolicyType;
+export interface OrganizationControlsPolicySummary extends BasePolicySummary {
+     type: "OrganizationControls";
      /**
       * Indicates whether MFA should be enabled for the organization. If set to true, this overrides any individual user's setting for MFA.                Once enabled, this cannot be disabled.
       */

--- a/http/v2/policy/session-recording/types/session-recording-policy-summary.types.ts
+++ b/http/v2/policy/session-recording/types/session-recording-policy-summary.types.ts
@@ -1,29 +1,7 @@
-import { Group } from '../../types/group.types';
-import { PolicyType } from '../../types/policy-type.types';
-import { Subject } from '../../types/subject.types';
+import { BasePolicySummary } from '../../types/base-policy-summary.types';
 
-export interface SessionRecordingPolicySummary {
-     /**
-      * Unique identifier for this policy.
-      */
-     id: string;
-     /**
-      * Name of policy.
-      */
-     name: string;
-     /**
-      * Description of policy.
-      */
-     description: string;
-     /**
-      * Users and API Keys that this policy applies to.
-      */
-     subjects: Subject[];
-     /**
-      * Groups that this policy applies to.
-      */
-     groups: Group[];
-     type: PolicyType;
+export interface SessionRecordingPolicySummary extends BasePolicySummary {
+     type: 'SessionRecording';
      /**
       * Indicates whether the session input should be recorded.
       */

--- a/http/v2/policy/target-connect/types/target-connect-policy-summary.types.ts
+++ b/http/v2/policy/target-connect/types/target-connect-policy-summary.types.ts
@@ -1,33 +1,11 @@
+import { BasePolicySummary } from '../../types/base-policy-summary.types';
 import { Environment } from '../../types/environment.types';
-import { Group } from '../../types/group.types';
-import { PolicyType } from '../../types/policy-type.types';
-import { Subject } from '../../types/subject.types';
 import { TargetUser } from '../../types/target-user.types';
 import { Target } from '../../types/target.types';
 import { Verb } from '../../types/verb.types';
 
-export interface TargetConnectPolicySummary {
-     /**
-      * Unique identifier for this policy.
-      */
-     id: string;
-     /**
-      * Name of policy.
-      */
-     name: string;
-     /**
-      * Description of policy.
-      */
-     description: string;
-     /**
-      * Users and API Keys that this policy applies to.
-      */
-     subjects: Subject[];
-     /**
-      * Groups that this policy applies to.
-      */
-     groups: Group[];
-     type: PolicyType;
+export interface TargetConnectPolicySummary extends BasePolicySummary {
+     type: "TargetConnect"
      /**
       * Environments this policy applies to.
       */

--- a/http/v2/policy/types/base-policy-summary.types.ts
+++ b/http/v2/policy/types/base-policy-summary.types.ts
@@ -1,0 +1,30 @@
+import { Group } from "./group.types";
+import { Subject } from "./subject.types";
+import { PolicyType } from "./policy-type.types";
+
+export interface BasePolicySummary {
+    /**
+     * Unique identifier for this policy.
+    */
+    id: string;
+    /**
+     * Name of policy.
+     */
+    name: string;
+    /**
+     * Description of policy.
+     */
+    description: string;
+    /**
+     * Users and API Keys that this policy applies to.
+     */
+    subjects: Subject[];
+    /**
+     * Groups that this policy applies to.
+     */
+    groups: Group[];
+    /**
+     * Type of policy
+     */
+    type: PolicyType;
+}

--- a/http/v2/policy/types/policy-type.types.ts
+++ b/http/v2/policy/types/policy-type.types.ts
@@ -1,6 +1,8 @@
-export enum PolicyType {
+export enum PolicyTypeEnum {
      TargetConnect = 'TargetConnect',
      OrganizationControls = 'OrganizationControls',
      SessionRecording = 'SessionRecording',
      KubernetesTunnel = 'KubernetesTunnel'
  };
+
+export type PolicyType = `${PolicyTypeEnum}`;


### PR DESCRIPTION
## Description of the change

The base policy reduces repetition. The string union allows for better
type safety. The combination of the two allows for generalized code that
operates on the shared properties (as defined in the base interface) of
a union type. Then, the union type can be discriminated by switching on
the string union allowing for access of the unshared properties without
having to do a type cast.

Requires TypeScript 4.1

## Relevant release note information

Release Notes: More type safety and reduce code repetition

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: